### PR TITLE
修复高阶组件类型导入未生效的问题

### DIFF
--- a/packages/demo/script/watch/config.js
+++ b/packages/demo/script/watch/config.js
@@ -20,16 +20,16 @@ const config = {
   sourceDir: path.resolve(__dirname, '../../../tdesign'),
   chatSourceDir: path.resolve(__dirname, '../../../tdesign-uniapp-chat'),
 
-  sourceGlob: path.resolve(__dirname, '../../../tdesign/**/*'),
-  chatSourceGlob: path.resolve(__dirname, '../../../tdesign-uniapp-chat/**/*'),
-  baseAndChatSourceGlob: path.resolve(__dirname, '../../../{tdesign,tdesign-uniapp-chat}/**/*'),
+  sourceGlob: path.resolve(__dirname, '../../../tdesign/**/*').replace(/\\/g, '/'),
+  chatSourceGlob: path.resolve(__dirname, '../../../tdesign-uniapp-chat/**/*').replace(/\\/g, '/'),
+  baseAndChatSourceGlob: path.resolve(__dirname, '../../../{tdesign,tdesign-uniapp-chat}/**/*').replace(/\\/g, '/'),
 
   demoDir: path.resolve(__dirname, '../../src/pages-more'),
 
   demoRealDir: path.resolve(__dirname, '../../'),
 
-  demoPagesGlob: path.resolve(__dirname, '../../src/pages/**/*'),
-  demoComponentsGlob: path.resolve(__dirname, '../../src/components/**/*'),
+  demoPagesGlob: path.resolve(__dirname, '../../src/pages/**/*').replace(/\\/g, '/'),
+  demoComponentsGlob: path.resolve(__dirname, '../../src/components/**/*').replace(/\\/g, '/'),
 
   appDir: path.resolve(__dirname, '../../../tdesign-app'),
   appPagesMoreDir: path.resolve(__dirname, '../../../tdesign-app/pages-more'),

--- a/packages/tdesign-uniapp-chat/global.d.ts
+++ b/packages/tdesign-uniapp-chat/global.d.ts
@@ -1,14 +1,14 @@
 declare module 'vue' {
   export interface GlobalComponents {
-    TAttachments: typeof import('tdesign-uniapp/attachments/attachments.vue').default;
-    TChatActionbar: typeof import('tdesign-uniapp/chat-actionbar/chat-actionbar.vue').default;
-    TChatContent: typeof import('tdesign-uniapp/chat-content/chat-content.vue').default;
-    TChatList: typeof import('tdesign-uniapp/chat-list/chat-list.vue').default;
-    TChatLoading: typeof import('tdesign-uniapp/chat-loading/chat-loading.vue').default;
-    TChatMarkdown: typeof import('tdesign-uniapp/chat-markdown/chat-markdown.vue').default;
-    TChatMessage: typeof import('tdesign-uniapp/chat-message/chat-message.vue').default;
-    TChatSender: typeof import('tdesign-uniapp/chat-sender/chat-sender.vue').default;
-    TChatThinking: typeof import('tdesign-uniapp/chat-thinking/chat-thinking.vue').default;
+    TAttachments: typeof import('tdesign-uniapp-chat/attachments/attachments.vue').default;
+    TChatActionbar: typeof import('tdesign-uniapp-chat/chat-actionbar/chat-actionbar.vue').default;
+    TChatContent: typeof import('tdesign-uniapp-chat/chat-content/chat-content.vue').default;
+    TChatList: typeof import('tdesign-uniapp-chat/chat-list/chat-list.vue').default;
+    TChatLoading: typeof import('tdesign-uniapp-chat/chat-loading/chat-loading.vue').default;
+    TChatMarkdown: typeof import('tdesign-uniapp-chat/chat-markdown/chat-markdown.vue').default;
+    TChatMessage: typeof import('tdesign-uniapp-chat/chat-message/chat-message.vue').default;
+    TChatSender: typeof import('tdesign-uniapp-chat/chat-sender/chat-sender.vue').default;
+    TChatThinking: typeof import('tdesign-uniapp-chat/chat-thinking/chat-thinking.vue').default;
   }
 }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1. 修复Windows开发下，路径不对导致命令：pnpm run init 命令执行失败的问题。
2. 修复tsconfig.json导入高阶组件chat的类型时，类型路径错误导致没有应用上的问题。

### 📝 更新日志

[chore: 🤖 normalize glob paths for Windows](https://github.com/novlan1/tdesign-uniapp/commit/363b88df95909d1c46cc40a1b75b0249e3e43b92)

[fix: 🐛 correct module paths in global.d.ts](https://github.com/novlan1/tdesign-uniapp/commit/dc739a68d12de4a743d02658f45e6062898156e3)

#### tdesign-uniapp
<!--
- feat(组件名称): 处理问题或特性描述
-->

无

#### tdesign-uniapp-chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

- fix: 🐛 correct module paths in global.d.ts

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
